### PR TITLE
移除Chart类的notes_count属性

### DIFF
--- a/chart.py
+++ b/chart.py
@@ -4,23 +4,21 @@ from judge_line import JudgeLine
 class Chart:
     version: int
     offset: float
-    notes_count: int
     judge_lines: list[JudgeLine]
 
-    def __init__(self, version: int, offset: float, notes_count: int, judge_lines: list[JudgeLine]):
+    def __init__(self, version: int, offset: float, judge_lines: list[JudgeLine]):
         self.version = version
         self.offset = offset
-        self.notes_count = notes_count
         self.judge_lines = judge_lines
 
     @classmethod
     def from_dict(cls, d: dict):
         version = d['formatVersion']
         if version == 1:
-            return cls(version, d['offset'], d['numOfNotes'],
+            return cls(version, d['offset'],
                        [*map(JudgeLine.from_dict_v1, d['judgeLineList'])])
         else:
-            return cls(version, d['offset'], d['numOfNotes'],
+            return cls(version, d['offset'],
                        [*map(JudgeLine.from_dict, d['judgeLineList'])])
 
 


### PR DESCRIPTION
从2.5.0提取的非Legacy铺面文件里没有'numOfNotes'，会导致解析卡住。